### PR TITLE
#155965539 Increase set timeouts and grace values for days exceeding 30

### DIFF
--- a/hc/api/schemas.py
+++ b/hc/api/schemas.py
@@ -2,8 +2,8 @@ check = {
     "properties": {
         "name": {"type": "string"},
         "tags": {"type": "string"},
-        "timeout": {"type": "number", "minimum": 60, "maximum": 604800},
-        "grace": {"type": "number", "minimum": 60, "maximum": 604800},
+        "timeout": {"type": "number", "minimum": 60, "maximum": 5184000},
+        "grace": {"type": "number", "minimum": 60, "maximum": 5184000},
         "channels": {"type": "string"}
     }
 }

--- a/hc/front/forms.py
+++ b/hc/front/forms.py
@@ -18,8 +18,8 @@ class NameTagsForm(forms.Form):
 
 
 class TimeoutForm(forms.Form):
-    timeout = forms.IntegerField(min_value=60, max_value=2592000)
-    grace = forms.IntegerField(min_value=60, max_value=2592000)
+    timeout = forms.IntegerField(min_value=60, max_value=29030400)
+    grace = forms.IntegerField(min_value=60, max_value=29030400)
 
 
 class AddChannelForm(forms.ModelForm):

--- a/hc/front/templatetags/hc_extras.py
+++ b/hc/front/templatetags/hc_extras.py
@@ -22,7 +22,7 @@ def hc_duration(td):
     remaining_seconds = int(td.total_seconds())
     result = []
 
-    for unit in (WEEK, DAY, HOUR, MINUTE):
+    for unit in (YEAR, MONTH,WEEK, DAY, HOUR, MINUTE):
         if unit == WEEK and remaining_seconds % unit.nsecs != 0:
             # Say "8 days" instead of "1 week 1 day"
             continue

--- a/hc/front/templatetags/hc_extras.py
+++ b/hc/front/templatetags/hc_extras.py
@@ -13,6 +13,8 @@ MINUTE = Unit("minute", 60)
 HOUR = Unit("hour", MINUTE.nsecs * 60)
 DAY = Unit("day", HOUR.nsecs * 24)
 WEEK = Unit("week", DAY.nsecs * 7)
+MONTH = Unit("month", WEEK.nsecs * 4)
+YEAR = Unit("year", MONTH.nsecs * 12)
 
 
 @register.filter

--- a/hc/front/tests/test_hc_extras.py
+++ b/hc/front/tests/test_hc_extras.py
@@ -13,9 +13,9 @@ class HcExtrasTestCase(TestCase):
             (3660, "1 hour 1 minute"),
             (86400, "1 day"),
             (604800, "1 week"),
-            (2419200, "4 weeks"),
-            (2592000, "30 days"),
-            (3801600, "44 days")
+            (2419200, "1 month"),
+            (14515200, "6 months"),
+            (29030400, "1 year")
         ]
 
         for seconds, expected_result in samples:

--- a/static/js/checks.js
+++ b/static/js/checks.js
@@ -4,7 +4,9 @@ $(function () {
     var HOUR = {name: "hour", nsecs: MINUTE.nsecs * 60};
     var DAY = {name: "day", nsecs: HOUR.nsecs * 24};
     var WEEK = {name: "week", nsecs: DAY.nsecs * 7};
-    var UNITS = [WEEK, DAY, HOUR, MINUTE];
+    var MONTH = {name: "month", nsecs: WEEK.nsecs * 4};
+    var YEAR = {name: "year", nsecs: MONTH.nsecs * 12};
+    var UNITS = [YEAR, MONTH, WEEK, DAY, HOUR, MINUTE];
 
     var secsToText = function(total) {
         var remainingSeconds = Math.floor(total);
@@ -32,18 +34,19 @@ $(function () {
 
     var periodSlider = document.getElementById("period-slider");
     noUiSlider.create(periodSlider, {
-        start: [20],
+        start: [5],
         connect: "lower",
         range: {
             'min': [60, 60],
-            '33%': [3600, 3600],
-            '66%': [86400, 86400],
-            '83%': [604800, 604800],
-            'max': 2592000,
+            '20%': [3600, 3600],
+            '40%': [86400, 86400],
+            '60%': [604800, 604800],
+            '75%': [2419200, 2419200],
+            'max': 29030400,
         },
         pips: {
             mode: 'values',
-            values: [60, 1800, 3600, 43200, 86400, 604800, 2592000],
+            values: [60, 3600, 86400, 604800, 2419200, 29030400],
             density: 4,
             format: {
                 to: secsToText,
@@ -53,6 +56,7 @@ $(function () {
     });
 
     periodSlider.noUiSlider.on("update", function(a, b, value) {
+        debugger;
         var rounded = Math.round(value);
         $("#period-slider-value").text(secsToText(rounded));
         $("#update-timeout-timeout").val(rounded);
@@ -61,18 +65,19 @@ $(function () {
 
     var graceSlider = document.getElementById("grace-slider");
     noUiSlider.create(graceSlider, {
-        start: [20],
+        start: [0],
         connect: "lower",
         range: {
             'min': [60, 60],
-            '33%': [3600, 3600],
-            '66%': [86400, 86400],
-            '83%': [604800, 604800],
-            'max': 2592000,
+            '20%': [3600, 3600],
+            '40%': [86400, 86400],
+            '60%': [604800, 604800],
+            '75%': [2419200, 2419200],
+            'max': 29030400,
         },
         pips: {
             mode: 'values',
-            values: [60, 1800, 3600, 43200, 86400, 604800, 2592000],
+            values: [60, 3600, 86400, 604800, 2419200, 29030400],
             density: 4,
             format: {
                 to: secsToText,

--- a/static/js/checks.js
+++ b/static/js/checks.js
@@ -56,7 +56,6 @@ $(function () {
     });
 
     periodSlider.noUiSlider.on("update", function(a, b, value) {
-        debugger;
         var rounded = Math.round(value);
         $("#period-slider-value").text(secsToText(rounded));
         $("#update-timeout-timeout").val(rounded);

--- a/templates/front/my_checks.html
+++ b/templates/front/my_checks.html
@@ -131,6 +131,7 @@
                             1 day
                         </span>
                     </div>
+                    
                     <div id="period-slider"></div>
 
                     <div class="update-timeout-info text-center">


### PR DESCRIPTION
#### What does this PR do?
Increase set timeouts and grace values for days exceeding 30
#### Description of Task to be completed?
User should be able to set timeouts and grace values for days exceeding 30
* As a user I want to be able configure long term checks for checks longer than 30 days
* As a user I want to be able to configure daily, weekly and monthly checks
#### How should this be manually tested?
After cloning the repo run `python manage.py runserver`. Navigate to your checks then click timeout period and grace period button
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#155965539](https://www.pivotaltracker.com/story/show/155965539)
#### Screenshots (if appropriate)
<img width="1280" alt="screen shot 2018-04-06 at 12 38 52" src="https://user-images.githubusercontent.com/17454824/38414718-f0fd4034-3997-11e8-8abd-262da641e193.png">
* Setting periods to monthly and yearly
<img width="1280" alt="screen shot 2018-04-06 at 12 44 23" src="https://user-images.githubusercontent.com/17454824/38414824-4a8a1898-3998-11e8-9e33-5ca53da2c6b4.png">

#### Questions:
N/A